### PR TITLE
Fixed two run time exceptions

### DIFF
--- a/lib/date_range_picker.dart
+++ b/lib/date_range_picker.dart
@@ -654,8 +654,7 @@ class _MonthPickerState extends State<MonthPicker>
   @override
   void didUpdateWidget(MonthPicker oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.selectedLastDate == null &&
-        widget.selectedFirstDate != oldWidget.selectedFirstDate) {
+    if (widget.selectedLastDate == null) {
       final int monthPage =
           _monthDelta(widget.firstDate, widget.selectedFirstDate);
       _dayPickerController = new PageController(initialPage: monthPage);
@@ -919,7 +918,7 @@ class _YearPickerState extends State<YearPicker> {
   void initState() {
     super.initState();
     int offset;
-    if (widget.selectedLastDate == null) {
+    if (widget.selectedLastDate != null) {
       offset = widget.lastDate.year - widget.selectedLastDate.year;
     } else {
       offset = widget.selectedFirstDate.year - widget.firstDate.year;


### PR DESCRIPTION
Exception 1: occurred when you select a start date, then end date, then re-select the same start date. This was causing the code to reference an end date that was already cleared. I removed the condition         `widget.selectedFirstDate != oldWidget.selectedFirstDate` which fixed the exception. I have not been able to find any error caused by this removal.

Exception 2: occurred when you select to change the year with only a start date selected. I changed the conditional that was checking if `selectedLastDate == null` and then using `selectedLastDate`, to checking if it was `!= null`. Fixed the error I saw and have not been able to produce any new issues with this change.