### PR TITLE
Fix a misstype on DateRagePicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ Add to `pubspec.yaml` in `dependencies`
 
 ### Usage
 ```
-import 'package:date_range_picker/date_range_picker.dart' as DateRagePicker;
+import 'package:date_range_picker/date_range_picker.dart' as DateRangePicker;
 ...
 new MaterialButton(
     color: Colors.deepOrangeAccent,
     onPressed: () async {
-      final List<DateTime> picked = await DateRagePicker.showDatePicker(
+      final List<DateTime> picked = await DateRangePicker.showDatePicker(
           context: context,
           initialFirstDate: new DateTime.now(),
           initialLastDate: (new DateTime.now()).add(new Duration(days: 7)),


### PR DESCRIPTION
This commit will fix a misstype in `README.md`. 
`DateRagePicker` will be changed to `DateRangePicker`.